### PR TITLE
Fix error message complaining about missing headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports.fetchAndCollect = async function fetchAndCollect(request) {
     .filter(Boolean);
 
   if (missingHeaders.length)
-    throw new Error(`Missing headers on the request: ${missingHeaders.join(', ')}`);
+    throw new Error(`Missing headers on the response: ${missingHeaders.join(', ')}`);
 
   const { res, body: responseBody } = await getResponseBody(response);
 

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ module.exports.metrics = function readme(apiKey, group, req, har) {
     body: JSON.stringify([
       {
         group,
-        clientIPAddress: req.headers.get('cf-connecting-ip'),
+        clientIPAddress: req.headers.get('cf-connecting-ip') || '0.0.0.0',
         request: har,
       },
     ]),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -37,7 +37,7 @@ describe('worker', () => {
         await requireWorker().fetchAndCollect(request);
       } catch (e) {
         called = true;
-        assert.equal(e.message, 'Missing headers on the request: x-readme-id, x-readme-label');
+        assert.equal(e.message, 'Missing headers on the response: x-readme-id, x-readme-label');
       }
       assert(called);
 


### PR DESCRIPTION
We used to (incorrectly) look for these headers on the request object
then we switched to correctly looking on the API response, but I forgot
to change the error message.