### PR TITLE
fix: package.json points to the wrong git url

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "git@github.com:readme/cloudflare-worker.git"
+    "url": "git@github.com:readmeio/cloudflare-worker.git"
   },
   "devDependencies": {
     "eslint": "^5.2.0",


### PR DESCRIPTION
Saw this when clicking through from https://www.npmjs.com/package/@readme/cloudflare-worker. Once this is merged, you should tag a new release so the link on NPM gets updated.