### PR TITLE
feature/allow-x-readme-email

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,7 @@
+module.exports.CONSTANTS = {
+  HEADERS: {
+    EMAIL: 'x-readme-email',
+    ID: 'x-readme-id',
+    LABEL: 'x-readme-label',
+  },
+};

--- a/dist/main.js
+++ b/dist/main.js
@@ -81,15 +81,29 @@
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
 /******/ })
 /************************************************************************/
 /******/ ([
 /* 0 */
+/***/ (function(module, exports) {
+
+module.exports.CONSTANTS = {
+  HEADERS: {
+    EMAIL: 'x-readme-email',
+    ID: 'x-readme-id',
+    LABEL: 'x-readme-label',
+  },
+};
+
+
+/***/ }),
+/* 1 */
 /***/ (function(module, exports, __webpack_require__) {
 
-const readme = __webpack_require__(1);
-const matchRouteWhitelist = __webpack_require__(2);
+const readme = __webpack_require__(2);
+const matchRouteWhitelist = __webpack_require__(3);
+const { CONSTANTS } = __webpack_require__(0);
 
 addEventListener('fetch', event => {
   event.passThroughOnException();
@@ -105,8 +119,9 @@ async function respond(event) {
   const { response, har } = await readme.fetchAndCollect(event.request);
 
   event.waitUntil(readme.metrics(event.request.authentications.account.token.token, {
-    id: response.headers.get('x-readme-id'),
-    label: response.headers.get('x-readme-label'),
+    id: response.headers.get(CONSTANTS.HEADERS.ID),
+    email: response.headers.get(CONSTANTS.HEADERS.EMAIL),
+    label: response.headers.get(CONSTANTS.HEADERS.LABEL),
   }, event.request, har));
 
   return response;
@@ -114,11 +129,12 @@ async function respond(event) {
 
 
 /***/ }),
-/* 1 */
+/* 2 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* eslint-env worker */
 /* global HOST, VERSION */
+const { CONSTANTS } = __webpack_require__(0);
 
 async function getRequestBody(request) {
   if (request.method.match(/GET|HEAD/)) {
@@ -181,7 +197,8 @@ module.exports.fetchAndCollect = async function fetchAndCollect(request) {
   const { req, body: requestBody } = await getRequestBody(request);
 
   const response = await fetch(req);
-  const requiredHeaders = ['x-readme-id', 'x-readme-label'];
+  const requiredHeaders = [CONSTANTS.HEADERS.ID, CONSTANTS.HEADERS.LABEL];
+  const readmeHeaders = [CONSTANTS.HEADERS.ID, CONSTANTS.HEADERS.LABEL, CONSTANTS.HEADERS.EMAIL];
 
   const missingHeaders = requiredHeaders
     .map(header => {
@@ -223,7 +240,7 @@ module.exports.fetchAndCollect = async function fetchAndCollect(request) {
             headers: [...res.headers]
               .map(([name, value]) => ({ name, value }))
               // Strip out x-readme-* headers
-              .filter(header => requiredHeaders.indexOf(header.name) === -1),
+              .filter(header => readmeHeaders.indexOf(header.name) === -1),
             content: {
               text: responseBody,
               size: responseBody.length,
@@ -267,10 +284,10 @@ module.exports.metrics = function readme(apiKey, group, req, har) {
 
 
 /***/ }),
-/* 2 */
+/* 3 */
 /***/ (function(module, exports, __webpack_require__) {
 
-const minimatch = __webpack_require__(3);
+const minimatch = __webpack_require__(4);
 
 module.exports = url =>
   INSTALL_OPTIONS.routes
@@ -280,7 +297,7 @@ module.exports = url =>
 
 
 /***/ }),
-/* 3 */
+/* 4 */
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports = minimatch
@@ -288,11 +305,11 @@ minimatch.Minimatch = Minimatch
 
 var path = { sep: '/' }
 try {
-  path = __webpack_require__(4)
+  path = __webpack_require__(5)
 } catch (er) {}
 
 var GLOBSTAR = minimatch.GLOBSTAR = Minimatch.GLOBSTAR = {}
-var expand = __webpack_require__(6)
+var expand = __webpack_require__(7)
 
 var plTypes = {
   '!': { open: '(?:(?!(?:', close: '))[^/]*?)'},
@@ -1209,7 +1226,7 @@ function regExpEscape (s) {
 
 
 /***/ }),
-/* 4 */
+/* 5 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(process) {// Copyright Joyent, Inc. and other Node contributors.
@@ -1437,10 +1454,10 @@ var substr = 'ab'.substr(-1) === 'b'
     }
 ;
 
-/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(5)))
+/* WEBPACK VAR INJECTION */}.call(this, __webpack_require__(6)))
 
 /***/ }),
-/* 5 */
+/* 6 */
 /***/ (function(module, exports) {
 
 // shim for using process in browser
@@ -1630,11 +1647,11 @@ process.umask = function() { return 0; };
 
 
 /***/ }),
-/* 6 */
+/* 7 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var concatMap = __webpack_require__(7);
-var balanced = __webpack_require__(8);
+var concatMap = __webpack_require__(8);
+var balanced = __webpack_require__(9);
 
 module.exports = expandTop;
 
@@ -1837,7 +1854,7 @@ function expand(str, isTop) {
 
 
 /***/ }),
-/* 7 */
+/* 8 */
 /***/ (function(module, exports) {
 
 module.exports = function (xs, fn) {
@@ -1856,7 +1873,7 @@ var isArray = Array.isArray || function (xs) {
 
 
 /***/ }),
-/* 8 */
+/* 9 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 /* eslint-env worker */
 /* global HOST, VERSION */
+const { CONSTANTS } = require('./constants.js');
 
 async function getRequestBody(request) {
   if (request.method.match(/GET|HEAD/)) {
@@ -62,7 +63,8 @@ module.exports.fetchAndCollect = async function fetchAndCollect(request) {
   const { req, body: requestBody } = await getRequestBody(request);
 
   const response = await fetch(req);
-  const requiredHeaders = ['x-readme-id', 'x-readme-label'];
+  const requiredHeaders = [CONSTANTS.HEADERS.ID, CONSTANTS.HEADERS.LABEL];
+  const readmeHeaders = [CONSTANTS.HEADERS.ID, CONSTANTS.HEADERS.LABEL, CONSTANTS.HEADERS.EMAIL];
 
   const missingHeaders = requiredHeaders
     .map(header => {
@@ -104,7 +106,7 @@ module.exports.fetchAndCollect = async function fetchAndCollect(request) {
             headers: [...res.headers]
               .map(([name, value]) => ({ name, value }))
               // Strip out x-readme-* headers
-              .filter(header => requiredHeaders.indexOf(header.name) === -1),
+              .filter(header => readmeHeaders.indexOf(header.name) === -1),
             content: {
               text: responseBody,
               size: responseBody.length,

--- a/template.js
+++ b/template.js
@@ -1,5 +1,6 @@
 const readme = require('@readme/cloudflare-worker');
 const matchRouteWhitelist = require('./lib/cloudflare-routing.js');
+const { CONSTANTS } = require('./constants.js');
 
 addEventListener('fetch', event => {
   event.passThroughOnException();
@@ -15,8 +16,9 @@ async function respond(event) {
   const { response, har } = await readme.fetchAndCollect(event.request);
 
   event.waitUntil(readme.metrics(event.request.authentications.account.token.token, {
-    id: response.headers.get('x-readme-id'),
-    label: response.headers.get('x-readme-label'),
+    id: response.headers.get(CONSTANTS.HEADERS.ID),
+    email: response.headers.get(CONSTANTS.HEADERS.EMAIL),
+    label: response.headers.get(CONSTANTS.HEADERS.LABEL),
   }, event.request, har));
 
   return response;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -215,6 +215,8 @@ describe('worker', () => {
 
       const { har } = await requireWorker().fetchAndCollect(request);
       const headers = har.log.entries[0].response.headers.map(h => h.name);
+      assert.equal(headers.indexOf('x-readme-id'), -1);
+      assert.equal(headers.indexOf('x-readme-label'), -1);
       assert.equal(headers.indexOf('x-readme-email'), -1);
     });
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -195,6 +195,28 @@ describe('worker', () => {
       // it can be returned from the service worker
       await response.json();
     });
+
+    it('should strip out any x-readme-headers', async () => {
+      const request = new global.Request('https://example.com/a?b=2', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ c: 3, d: 4 }),
+      });
+      nock('https://example.com')
+        .post('/a?b=2', JSON.stringify({ c: 3, d: 4 }))
+        .reply(200, '', {
+          'x-readme-id': 'id',
+          'x-readme-label': 'label',
+          'x-readme-email': 'myEmail',
+          coronavirus: 'activated',
+        });
+
+      const { har } = await requireWorker().fetchAndCollect(request);
+      const headers = har.log.entries[0].response.headers.map(h => h.name);
+      assert.equal(headers.indexOf('x-readme-email'), -1);
+    });
   });
 
   describe('#metrics()', () => {

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -44,6 +44,7 @@ describe('template', () => {
   it('should send x-readme-* headers through to metrics backend', done => {
     const id = 123456;
     const label = 'api-key-label';
+    const email = 'test@readme.io';
     const server = http
       .createServer((req, res) => {
         let body = '';
@@ -54,6 +55,7 @@ describe('template', () => {
           body = JSON.parse(body);
           assert.equal(body[0].group.id, id);
           assert.equal(body[0].group.label, label);
+          assert.equal(body[0].group.email, email);
           res.end();
           server.close();
           return done();
@@ -72,6 +74,7 @@ describe('template', () => {
       .reply(200, '', {
         'x-readme-id': id,
         'x-readme-label': label,
+        'x-readme-email': email,
       });
 
     const fetchEvent = new FetchEvent({
@@ -96,6 +99,7 @@ describe('template', () => {
       .reply(200, '', {
         'x-readme-id': '123456',
         'x-readme-label': 'api-key-label',
+        'x-readme-email': 'test@readme.io',
       });
 
     const event = new FetchEvent({


### PR DESCRIPTION
Prelim functionality for adding 'x-readme-email' to worker app: 
We'd like to add more context to calls for our frontend, and we currently only support sending label/id. Adding email for this purpose